### PR TITLE
fix split_export when account includes forwardslash character

### DIFF
--- a/split_export.py
+++ b/split_export.py
@@ -32,7 +32,7 @@ def main():
         result[account].append(line)
 
     for account, lines in result.items():
-        with open(f"ynab_split_{account}.csv", "w", encoding="utf-8-sig") as p:
+        with open("ynab_split_%s.csv" % (account.replace("/", ":")), "w", encoding="utf-8-sig") as p:
             writer = csv.DictWriter(
                 p,
                 fieldnames=[


### PR DESCRIPTION
Not sure if this makes sense or not. I have dates in some of my account names (student loan disbursements). On MacOS, swapping `/` with `:` will still display a `/` in Finder, but will allow the OS to interact with the file properly. 